### PR TITLE
feat: Include metadata in PromptTemplate build result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 coverage
+TODO.md

--- a/src/templates/partial-prompt-template.ts
+++ b/src/templates/partial-prompt-template.ts
@@ -1,5 +1,10 @@
 import { z, ZodTypeAny } from "zod";
-import { DeepPartial, PromptTemplateOptions } from "../types";
+import {
+  DeepPartial,
+  PromptTemplateBuildResult,
+  PromptTemplateBuildResultAsync,
+  PromptTemplateOptions,
+} from "../types";
 import { merge } from "lodash";
 import Handlebars from "handlebars";
 
@@ -7,6 +12,7 @@ import Handlebars from "handlebars";
  * Represents a template that can be built with partial data validated against a Zod schema.
  */
 export class PartialPromptTemplate<TSchema extends ZodTypeAny> {
+  private options: PromptTemplateOptions<TSchema>;
   private hb = Handlebars.create();
   private compiledTemplate = this.hb.compile(this.templateStr.trim());
   private partialData: DeepPartial<z.input<TSchema>> = {};
@@ -21,9 +27,10 @@ export class PartialPromptTemplate<TSchema extends ZodTypeAny> {
   constructor(
     private schema: TSchema,
     private templateStr: string,
-    private options?: PromptTemplateOptions,
+    { metadata, ...options }: PromptTemplateOptions<TSchema>,
   ) {
-    if (this.options?.helpers) {
+    this.options = { metadata: { ...metadata, type: "partial" }, ...options };
+    if (this.options.helpers) {
       Object.entries(this.options.helpers).forEach(([name, helper]) => {
         this.hb.registerHelper(name, helper);
       });
@@ -33,21 +40,37 @@ export class PartialPromptTemplate<TSchema extends ZodTypeAny> {
   /**
    * Builds the final template string by validating and processing the input data.
    *
-   * @returns The rendered template string.
+   * @returns An object containing the rendered template string and metadata.
    */
-  build(): string {
+  build(): PromptTemplateBuildResult<TSchema> {
     const result = this.schema.parse(this.partialData);
-    return this.compiledTemplate(result);
+    const prompt = this.compiledTemplate(result);
+    return {
+      prompt,
+      metadata: {
+        ...this.options.metadata,
+        templateStr: this.templateStr,
+        data: result,
+      },
+    };
   }
 
   /**
    * Asynchronously builds the final template string by validating and processing the input data.
    *
-   * @returns A promise that resolves to the rendered template string.
+   * @returns A promise that resolves to an object containing the rendered template string and metadata.
    */
-  async buildAsync(): Promise<string> {
+  async buildAsync(): PromptTemplateBuildResultAsync<TSchema> {
     const result = await this.schema.parseAsync(this.partialData);
-    return this.compiledTemplate(result);
+    const prompt = this.compiledTemplate(result);
+    return {
+      prompt,
+      metadata: {
+        ...this.options.metadata,
+        templateStr: this.templateStr,
+        data: result,
+      },
+    };
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,24 @@ export type DeepPartial<T> = {
 };
 
 /**
+ * Metadata associated with a PromptTemplate.
+ */
+export type PromptMetadata<TSchema extends ZodTypeAny> = {
+  templateId?: string;
+  experimentId?: string;
+  version?: string;
+  description?: string;
+  custom?: Record<string, any>;
+  type: "partial" | "full";
+  templateStr: string;
+  data: z.output<TSchema>;
+};
+
+/**
  *  Configuration options for a PromptTemplate instance.
  */
-export type PromptTemplateOptions = {
+export type PromptTemplateOptions<TSchema extends ZodTypeAny> = {
+  metadata: Omit<PromptMetadata<TSchema>, "templateStr" | "data">;
   helpers?: Record<string, HelperDelegate>;
 };
 
@@ -26,13 +41,26 @@ type PromptTemplateSchema<T extends PromptTemplate<ZodTypeAny>> =
  * Utility type that infers the *input* type of a PromptTemplate.
  * Essentially the same as `z.input<TSchema>`.
  */
-export type PromptTemplateInput<T extends PromptTemplate<ZodTypeAny>> = z.input<
-  PromptTemplateSchema<T>
->;
+export type PromptTemplateDataInput<T extends PromptTemplate<ZodTypeAny>> =
+  z.input<PromptTemplateSchema<T>>;
 
 /**
  * Utility type that infers the *output* type of a PromptTemplate.
  * Essentially the same as `z.output<TSchema>`.
  */
-export type PromptTemplateOutput<T extends PromptTemplate<ZodTypeAny>> =
+export type PromptTemplateDataOutput<T extends PromptTemplate<ZodTypeAny>> =
   z.output<PromptTemplateSchema<T>>;
+
+/**
+ * The result of a PromptTemplate build operation.
+ */
+export type PromptTemplateBuildResult<TSchema extends ZodTypeAny> = {
+  prompt: string;
+  metadata: PromptMetadata<TSchema>;
+};
+
+/**
+ * The result of a PromptTemplate build operation, returned asynchronously.
+ */
+export type PromptTemplateBuildResultAsync<TSchema extends ZodTypeAny> =
+  Promise<PromptTemplateBuildResult<TSchema>>;

--- a/test/test-d/index.test-d.ts
+++ b/test/test-d/index.test-d.ts
@@ -2,7 +2,10 @@ import { z } from "zod";
 import { expectNotType, expectType } from "tsd";
 
 import { promptTemplate } from "../../src/index";
-import { PromptTemplateInput, PromptTemplateOutput } from "../../src/types";
+import {
+  PromptTemplateDataInput,
+  PromptTemplateDataOutput,
+} from "../../src/types";
 
 const myTemplate = promptTemplate(
   z.object({
@@ -12,10 +15,10 @@ const myTemplate = promptTemplate(
   "Hello {{name}}, you are {{age}} years old!",
 );
 
-type MyTemplateInput = PromptTemplateInput<typeof myTemplate>;
+type MyTemplateInput = PromptTemplateDataInput<typeof myTemplate>;
 expectType<{ name: string; age: number }>(null as unknown as MyTemplateInput);
 
-type MyTemplateOutput = PromptTemplateOutput<typeof myTemplate>;
+type MyTemplateOutput = PromptTemplateDataOutput<typeof myTemplate>;
 expectType<{ name: string; age: number }>(null as unknown as MyTemplateOutput);
 
 expectNotType<{ name: string }>(null as unknown as MyTemplateInput);


### PR DESCRIPTION
The `build`  and `buildAsync` methods now return an object that includes both the rendered template string () and metadata. This enhances usability by providing additional context directly in the result.

Although this is a breaking change, the package is in early development, so the major version is not being incremented.